### PR TITLE
Add String, Number Type for Select and Radio options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 2.8.0 (IN PROGRESS)
+
+### Features / Enhancements
+
+- Add String, Number Type for Select and Radio options (#120)
+
+### Bug fixes
+
+- Fix Password and Boolean elements confirmation (#120)
+
 ## 2.7.0 (2022-11-10)
 
 ### Features / Enhancements

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![YouTube](https://img.shields.io/badge/YouTube-Playlist-red)](https://www.youtube.com/playlist?list=PLPow72ygztmRXSNBxyw0sFnnvNRY_CsSA)
 ![CI](https://github.com/volkovlabs/volkovlabs-form-panel/workflows/CI/badge.svg)
 [![codecov](https://codecov.io/gh/VolkovLabs/volkovlabs-form-panel/branch/main/graph/badge.svg?token=0m6f0ktUar)](https://codecov.io/gh/VolkovLabs/volkovlabs-form-panel)
+[![CodeQL](https://github.com/VolkovLabs/volkovlabs-form-panel/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/VolkovLabs/volkovlabs-form-panel/actions/workflows/codeql-analysis.yml)
 
 ## Introduction
 

--- a/package.json
+++ b/package.json
@@ -28,5 +28,5 @@
     "upgrade": "yarn upgrade --latest",
     "watch": "grafana-toolkit plugin:dev --watch"
   },
-  "version": "2.7.0"
+  "version": "2.8.0"
 }

--- a/src/components/FormElementsEditor/FormElementsEditor.test.tsx
+++ b/src/components/FormElementsEditor/FormElementsEditor.test.tsx
@@ -214,7 +214,12 @@ describe('Panel', () => {
    */
   it('Should find component with Select', async () => {
     const elements = [
-      { ...FormElementDefault, id: 'select', type: FormElementType.SELECT, options: [{ id: 'id', label: 'label' }] },
+      {
+        ...FormElementDefault,
+        id: 'select',
+        type: FormElementType.SELECT,
+        options: [{ id: 'id', label: 'label', type: FormElementType.NUMBER }],
+      },
     ];
 
     const getComponent = ({ value = [], context = {}, ...restProps }: any) => {
@@ -232,13 +237,17 @@ describe('Panel', () => {
     expect(addButton.exists()).toBeTruthy();
     addButton.simulate('click');
 
-    const id = element.find('Input[placeholder="value"]');
+    const id = element.find('Input[placeholder="number"]');
     expect(id.exists()).toBeTruthy();
-    id.simulate('change', { target: { value: 'text' } });
+    id.simulate('change', { target: { value: 10 } });
 
     const label = element.find('Input[placeholder="label"]');
     expect(label.exists()).toBeTruthy();
     label.simulate('change', { target: { value: 'Id' } });
+
+    const select = element.find(`Select[defaultValue="string"]`);
+    expect(select.exists()).toBeTruthy();
+    select.simulate('change', { value: FormElementType.STRING });
 
     const removeButton = element.find('[icon="minus"]');
     expect(removeButton.exists()).toBeTruthy();

--- a/src/components/FormElementsEditor/FormElementsEditor.tsx
+++ b/src/components/FormElementsEditor/FormElementsEditor.tsx
@@ -17,6 +17,7 @@ import {
   FormElementDefault,
   FormElementType,
   FormElementTypeOptions,
+  SelectElementOptions,
   SliderDefault,
 } from '../../constants';
 import { FormElement, LayoutSection } from '../../types';
@@ -367,16 +368,44 @@ export const FormElementsEditor: React.FC<Props> = ({ value: elements, onChange,
             <div>
               {element.options?.map((option) => (
                 <InlineFieldRow key={option.id}>
-                  <InlineField label="Value" labelWidth={8}>
-                    <Input
-                      placeholder="value"
-                      onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                        option.value = event.target.value;
+                  <InlineField label="Type" labelWidth={8}>
+                    <Select
+                      options={SelectElementOptions}
+                      onChange={(event: SelectableValue) => {
+                        option.type = event?.value;
                         onChange(elements);
                       }}
-                      value={option.value}
+                      width={12}
+                      value={SelectElementOptions.find((type) => type.value === option.type)}
+                      defaultValue={FormElementType.STRING}
                     />
                   </InlineField>
+                  {(!option.type || option.type === FormElementType.STRING) && (
+                    <InlineField label="Value" labelWidth={8}>
+                      <Input
+                        placeholder="string"
+                        onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                          option.value = event.target.value;
+                          onChange(elements);
+                        }}
+                        value={option.value}
+                      />
+                    </InlineField>
+                  )}
+                  {option.type === FormElementType.NUMBER && (
+                    <InlineField label="Value" labelWidth={8}>
+                      <Input
+                        type="number"
+                        placeholder="number"
+                        onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                          option.value = Number(event.target.value);
+                          onChange(elements);
+                        }}
+                        value={option.value}
+                        width={12}
+                      />
+                    </InlineField>
+                  )}
                   <InlineField label="Label" labelWidth={8} grow>
                     <Input
                       placeholder="label"

--- a/src/components/FormPanel/FormPanel.tsx
+++ b/src/components/FormPanel/FormPanel.tsx
@@ -475,7 +475,7 @@ export const FormPanel: React.FC<Props> = ({
 
                   return (
                     <tr className={styles.confirmTable} key={element.id}>
-                      <td className={styles.confirmTableTd}>{element.title}</td>
+                      <td className={styles.confirmTableTd}>{element.title || element.tooltip}</td>
                       <td className={styles.confirmTableTd}>{initial[element.id]}</td>
                       <td className={styles.confirmTableTd}>{element.value}</td>
                     </tr>

--- a/src/components/FormPanel/FormPanel.tsx
+++ b/src/components/FormPanel/FormPanel.tsx
@@ -467,6 +467,19 @@ export const FormPanel: React.FC<Props> = ({
                   }
 
                   /**
+                   * Skip Password elements
+                   */
+                  if (element.type === FormElementType.PASSWORD) {
+                    return (
+                      <tr className={styles.confirmTable} key={element.id}>
+                        <td className={styles.confirmTableTd}>{element.title || element.tooltip}</td>
+                        <td className={styles.confirmTableTd}>*********</td>
+                        <td className={styles.confirmTableTd}>*********</td>
+                      </tr>
+                    );
+                  }
+
+                  /**
                    * Convert DateTime object to ISO string
                    */
                   if (element.type === FormElementType.DATETIME) {
@@ -476,8 +489,12 @@ export const FormPanel: React.FC<Props> = ({
                   return (
                     <tr className={styles.confirmTable} key={element.id}>
                       <td className={styles.confirmTableTd}>{element.title || element.tooltip}</td>
-                      <td className={styles.confirmTableTd}>{initial[element.id]}</td>
-                      <td className={styles.confirmTableTd}>{element.value}</td>
+                      <td className={styles.confirmTableTd}>
+                        {initial[element.id] === undefined ? '' : String(initial[element.id])}
+                      </td>
+                      <td className={styles.confirmTableTd}>
+                        {element.value === undefined ? '' : String(element.value)}
+                      </td>
                     </tr>
                   );
                 })}

--- a/src/constants/form-element.ts
+++ b/src/constants/form-element.ts
@@ -81,3 +81,17 @@ export const BooleanElementOptions: SelectableValue[] = [
     label: 'False',
   },
 ];
+
+/**
+ * Select and Radio Type Options
+ */
+export const SelectElementOptions: SelectableValue[] = [
+  {
+    value: FormElementType.STRING,
+    label: 'String',
+  },
+  {
+    value: FormElementType.NUMBER,
+    label: 'Number',
+  },
+];


### PR DESCRIPTION
If API returns a number, then Select and Radio elements with number inputs can correctly compare and display the correct option.

Options without type are considered to be strings.