### PR TITLE
MySQL Server API "Error: Packets out of order" fix

### DIFF
--- a/server-mysql/server.ts
+++ b/server-mysql/server.ts
@@ -14,15 +14,18 @@ const q1_post_sql_query_values = process.env.GRAFANA_API_SERVER_MYSQL_Q1_POST_SQ
 /**
  * Connect to Mysql
  */
-const client = mysql.createConnection({
+const client = mysql.createPool({
   host: process.env.GRAFANA_API_SERVER_MYSQL_HOST,
   user: process.env.GRAFANA_API_SERVER_MYSQL_USER,
   password: process.env.GRAFANA_API_SERVER_MYSQL_PASSWORD,
   database: process.env.GRAFANA_API_SERVER_MYSQL_DB
 });
-client.connect(function (err) {
+// Check MySQL connection
+client.getConnection(function (err, connection) {
+  // When done with the connection, destroy it.
+  connection.destroy();
   if (err) throw err;
-  console.log('Connected to the MySQL server!');
+  console.log('MySQL server connection is successful!');
 });
 
 /**


### PR DESCRIPTION
Every 8 hours MYSQL SERER API server gets an error `Error: Packets out of order` and docker container automatically restarts.

```text
node:events:491
throw er; // Unhandled 'error' event
^
Error: Packets out of order. Got: 0 Expected: 3
at Parser._tryReadPacketHeader (/home/node/app/node_modules/mysql/lib/protocol/Parser.js:470:15)
at Parser.write (/home/node/app/node_modules/mysql/lib/protocol/Parser.js:33:29)
at Protocol.write (/home/node/app/node_modules/mysql/lib/protocol/Protocol.js:38:16)
at Socket.<anonymous> (/home/node/app/node_modules/mysql/lib/Connection.js:88:28)
at Socket.<anonymous> (/home/node/app/node_modules/mysql/lib/Connection.js:526:10)
at Socket.emit (node:events:513:28)
at addChunk (node:internal/streams/readable:324:12)
at readableAddChunk (node:internal/streams/readable:297:9)
at Readable.push (node:internal/streams/readable:234:10)
at TCP.onStreamRead (node:internal/stream_base_commons:190:23)
Emitted 'error' event on Connection instance at:
at Connection._handleProtocolError (/home/node/app/node_modules/mysql/lib/Connection.js:423:8)
at Protocol.emit (node:events:513:28)
at Protocol._delegateError (/home/node/app/node_modules/mysql/lib/protocol/Protocol.js:398:10)
at Protocol.handleParserError (/home/node/app/node_modules/mysql/lib/protocol/Protocol.js:380:10)
at Parser._tryReadPacketHeader (/home/node/app/node_modules/mysql/lib/protocol/Parser.js:478:10)
at Parser.write (/home/node/app/node_modules/mysql/lib/protocol/Parser.js:33:29)
[... lines matching original stack trace ...]
at Socket.emit (node:events:513:28) {
code: 'PROTOCOL_PACKETS_OUT_OF_ORDER',
fatal: true
}
Node.js v18.12.1
```

MYSQL default wait_timeout is 8 hrs.
https://stackoverflow.com/questions/70645884/error-packets-out-of-order-got-0-expected-3

Solution: connection change from `createConnection` to `createPool`.