### PR TITLE
Add min and max date for date time element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 3.2.0 (IN PROGRESS)
+
+### Features / Enhancements
+
+- Add min and max date for date time element (#225)
+
 ## 3.1.0 (2023-08-13)
 
 ### Features / Enhancements

--- a/package.json
+++ b/package.json
@@ -71,5 +71,5 @@
     "test:ci": "jest --maxWorkers 4 --coverage",
     "upgrade": "npm upgrade --save"
   },
-  "version": "3.1.0"
+  "version": "3.2.0"
 }

--- a/src/__mocks__/@grafana/ui.tsx
+++ b/src/__mocks__/@grafana/ui.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { dateTime } from '@grafana/data';
 
 const actual = jest.requireActual('@grafana/ui');
 
@@ -34,7 +35,7 @@ const DateTimePicker = jest.fn(({ onChange, ...restProps }) => {
       value={restProps.value}
       onChange={(event) => {
         if (onChange) {
-          onChange(event.target.value);
+          onChange(dateTime(event.target.value));
         }
       }}
     />

--- a/src/components/ElementDateEditor/ElementDateEditor.tsx
+++ b/src/components/ElementDateEditor/ElementDateEditor.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Button, DateTimePicker, InlineField, InlineFieldRow } from '@grafana/ui';
+import { dateTime } from '@grafana/data';
+import { TestIds } from '../../constants';
+
+/**
+ * Properties
+ */
+interface Props {
+  /**
+   * Value
+   *
+   * @type {string}
+   */
+  value?: string;
+
+  /**
+   * On Change
+   *
+   * @param value
+   */
+  onChange: (value: string) => void;
+
+  /**
+   * Label
+   *
+   * @type {string}
+   */
+  label: string;
+
+  /**
+   * Data Test id
+   */
+  'data-testid': string;
+}
+
+/**
+ * Element Date Editor
+ */
+export const ElementDateEditor: React.FC<Props> = ({ value, onChange, label, ...restProps }) => (
+  <InlineFieldRow {...restProps}>
+    {!!value ? (
+      <>
+        <InlineField label={label} labelWidth={8}>
+          <DateTimePicker
+            onChange={(dateTime) => {
+              onChange(dateTime.toISOString());
+            }}
+            date={dateTime(value)}
+            data-testid={TestIds.formElementsEditor.fieldDateTime}
+          />
+        </InlineField>
+        <Button
+          icon="minus"
+          onClick={() => {
+            onChange('');
+          }}
+          variant="secondary"
+          data-testid={TestIds.formElementsEditor.buttonRemoveDate}
+        />
+      </>
+    ) : (
+      <InlineField label={label} labelWidth={8}>
+        <Button
+          icon="plus"
+          onClick={() => {
+            onChange(new Date().toISOString());
+          }}
+          variant="secondary"
+          data-testid={TestIds.formElementsEditor.buttonSetDate}
+        >
+          Set {label} Date
+        </Button>
+      </InlineField>
+    )}
+  </InlineFieldRow>
+);

--- a/src/components/ElementDateEditor/index.ts
+++ b/src/components/ElementDateEditor/index.ts
@@ -1,0 +1,1 @@
+export * from './ElementDateEditor';

--- a/src/components/ElementEditor/ElementEditor.tsx
+++ b/src/components/ElementEditor/ElementEditor.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../constants';
 import { LocalFormElement } from '../../types';
 import { FormatNumberValue, GetElementWithNewType, ToNumberValue } from '../../utils';
+import { ElementDateEditor } from '../ElementDateEditor';
 import { Styles } from './styles';
 
 /**
@@ -297,6 +298,33 @@ export const ElementEditor: React.FC<Props> = ({ element, onChange, onChangeOpti
             />
           </InlineField>
         </InlineFieldRow>
+      )}
+
+      {element.type === FormElementType.DATETIME && (
+        <>
+          <ElementDateEditor
+            label="Min"
+            onChange={(value) =>
+              onChange({
+                ...element,
+                min: value,
+              })
+            }
+            value={element.min}
+            data-testid={TestIds.formElementsEditor.fieldMinDate}
+          />
+          <ElementDateEditor
+            label="Max"
+            onChange={(value) =>
+              onChange({
+                ...element,
+                max: value,
+              })
+            }
+            value={element.max}
+            data-testid={TestIds.formElementsEditor.fieldMaxDate}
+          />
+        </>
       )}
 
       {element.type === FormElementType.TEXTAREA && (

--- a/src/components/FormElements/FormElements.test.tsx
+++ b/src/components/FormElements/FormElements.test.tsx
@@ -498,7 +498,15 @@ describe('Form Elements', () => {
         initial: { highlightColor: false },
         update: {},
         reset: {},
-        elements: [{ id: 'number', type: FormElementType.DATETIME, value: '2023-05-31 12:30:30' }],
+        elements: [
+          {
+            id: 'number',
+            type: FormElementType.DATETIME,
+            value: '2023-05-31 12:30:30',
+            min: '2023-05-20 12:30:30',
+            max: '2023-06-15 12:30:30',
+          },
+        ],
       };
       const onChangeElement = jest.fn();
 

--- a/src/components/FormElements/FormElements.tsx
+++ b/src/components/FormElements/FormElements.tsx
@@ -46,7 +46,7 @@ interface Props {
   /**
    * On Element Change
    */
-  onChangeElement: (element: LocalFormElement) => void;
+  onChangeElement: <T extends LocalFormElement>(element: T) => void;
 
   /**
    * Initial values
@@ -142,7 +142,7 @@ export const FormElements: React.FC<Props> = ({ options, elements, onChangeEleme
                       value = Math.max(element.min, value || 0);
                     }
 
-                    onChangeElement({
+                    onChangeElement<typeof element>({
                       ...element,
                       value,
                     });
@@ -169,7 +169,7 @@ export const FormElements: React.FC<Props> = ({ options, elements, onChangeEleme
                 <Input
                   value={element.value || ''}
                   onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                    onChangeElement({
+                    onChangeElement<typeof element>({
                       ...element,
                       value: event.target.value,
                     });
@@ -193,7 +193,7 @@ export const FormElements: React.FC<Props> = ({ options, elements, onChangeEleme
                 <Input
                   value={element.value || ''}
                   onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                    onChangeElement({
+                    onChangeElement<typeof element>({
                       ...element,
                       value: event.target.value,
                     });
@@ -239,7 +239,7 @@ export const FormElements: React.FC<Props> = ({ options, elements, onChangeEleme
                 <TextArea
                   value={element.value || ''}
                   onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
-                    onChangeElement({
+                    onChangeElement<typeof element>({
                       ...element,
                       value: event.target.value,
                     });
@@ -268,7 +268,7 @@ export const FormElements: React.FC<Props> = ({ options, elements, onChangeEleme
                   height={element.height || `${CodeEditorHeight}px`}
                   width={ApplyWidth(element.width)}
                   onBlur={(code) => {
-                    onChangeElement({
+                    onChangeElement<typeof element>({
                       ...element,
                       value: code,
                     });
@@ -291,7 +291,7 @@ export const FormElements: React.FC<Props> = ({ options, elements, onChangeEleme
                 <RadioButtonGroup
                   value={element.value}
                   onChange={(value: Boolean) => {
-                    onChangeElement({
+                    onChangeElement<typeof element>({
                       ...element,
                       value,
                     });
@@ -312,11 +312,13 @@ export const FormElements: React.FC<Props> = ({ options, elements, onChangeEleme
                 transparent={!element.title}
               >
                 <DateTimePicker
+                  minDate={element.min ? new Date(element.min) : undefined}
+                  maxDate={element.max ? new Date(element.max) : undefined}
                   date={dateTime(element.value)}
                   onChange={(dateTime: DateTime) => {
-                    onChangeElement({
+                    onChangeElement<typeof element>({
                       ...element,
-                      value: dateTime,
+                      value: dateTime.toISOString(),
                     });
                   }}
                   data-testid={TestIds.formElements.fieldDateTime}
@@ -336,10 +338,10 @@ export const FormElements: React.FC<Props> = ({ options, elements, onChangeEleme
                 >
                   <Slider
                     value={element.value || 0}
-                    onChange={(value: number | number[]) => {
-                      onChangeElement({
+                    onChange={(value) => {
+                      onChangeElement<typeof element>({
                         ...element,
-                        value,
+                        value: Array.isArray(value) ? value[value.length - 1] : value,
                       });
                     }}
                     min={element.min || 0}
@@ -356,7 +358,7 @@ export const FormElements: React.FC<Props> = ({ options, elements, onChangeEleme
                     max={element.max || 0}
                     value={element.value || 0}
                     onChange={(e) => {
-                      onChangeElement({
+                      onChangeElement<typeof element>({
                         ...element,
                         value: Math.max(element.min || 0, Math.min(element.max || 0, Number(e.currentTarget.value))),
                       });
@@ -379,7 +381,7 @@ export const FormElements: React.FC<Props> = ({ options, elements, onChangeEleme
                 <RadioButtonGroup
                   value={element.value}
                   onChange={(value: unknown) => {
-                    onChangeElement({
+                    onChangeElement<typeof element>({
                       ...element,
                       value,
                     });
@@ -404,7 +406,7 @@ export const FormElements: React.FC<Props> = ({ options, elements, onChangeEleme
                   aria-label={TestIds.formElements.fieldSelect}
                   value={element.value !== undefined ? element.value : null}
                   onChange={(event) => {
-                    onChangeElement({
+                    onChangeElement<typeof element>({
                       ...element,
                       value: Array.isArray(event) ? event.map(({ value }) => value) : event.value,
                     });

--- a/src/components/FormElementsEditor/FormElementsEditor.test.tsx
+++ b/src/components/FormElementsEditor/FormElementsEditor.test.tsx
@@ -928,7 +928,7 @@ describe('Form Elements Editor', () => {
       /**
        * Date is not set
        */
-      expect(fieldSelectors.fieldMinDate(true)).not.toBeInTheDocument();
+      expect(fieldSelectors.fieldMaxDate(true)).not.toBeInTheDocument();
     });
 
     it('Should update date min', async () => {

--- a/src/components/FormElementsEditor/FormElementsEditor.test.tsx
+++ b/src/components/FormElementsEditor/FormElementsEditor.test.tsx
@@ -869,6 +869,130 @@ describe('Form Elements Editor', () => {
       );
     });
 
+    it('Should update date max', async () => {
+      const element = { ...FormElementDefault, id: 'id', type: FormElementType.DATETIME, max: '' };
+      const elements = [element];
+      const onChange = jest.fn();
+
+      render(getComponent({ value: elements, onChange }));
+
+      /**
+       * Open id element
+       */
+      const elementSelectors = openElement(element.id, element.type);
+
+      const field = elementSelectors.fieldMaxDate();
+      const fieldSelectors = getFormElementsEditorSelectors(within(field));
+
+      /**
+       * Date is not set
+       */
+      expect(fieldSelectors.fieldMaxDate(true)).not.toBeInTheDocument();
+      expect(fieldSelectors.buttonSetDate()).toBeInTheDocument();
+
+      /**
+       * Set Date
+       */
+      await act(() => fireEvent.click(fieldSelectors.buttonSetDate()));
+
+      /**
+       * Date
+       */
+      expect(fieldSelectors.fieldDateTime()).toBeInTheDocument();
+
+      /**
+       * Change Date
+       */
+      const date = new Date('2021-07-31 12:30:30');
+      await act(() => fireEvent.change(fieldSelectors.fieldDateTime(), { target: { value: date.toISOString() } }));
+
+      expect(fieldSelectors.fieldDateTime()).toHaveValue(date.toISOString());
+
+      await act(() => fireEvent.click(selectors.buttonSaveChanges()));
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            max: date.toISOString(),
+          }),
+        ])
+      );
+
+      /**
+       * Remove Date
+       */
+      expect(fieldSelectors.buttonRemoveDate()).toBeInTheDocument();
+
+      await act(() => fireEvent.click(fieldSelectors.buttonRemoveDate()));
+
+      /**
+       * Date is not set
+       */
+      expect(fieldSelectors.fieldMinDate(true)).not.toBeInTheDocument();
+    });
+
+    it('Should update date min', async () => {
+      const element = { ...FormElementDefault, id: 'id', type: FormElementType.DATETIME, min: '' };
+      const elements = [element];
+      const onChange = jest.fn();
+
+      render(getComponent({ value: elements, onChange }));
+
+      /**
+       * Open id element
+       */
+      const elementSelectors = openElement(element.id, element.type);
+
+      const field = elementSelectors.fieldMinDate();
+      const fieldSelectors = getFormElementsEditorSelectors(within(field));
+
+      /**
+       * Date is not set
+       */
+      expect(fieldSelectors.fieldMinDate(true)).not.toBeInTheDocument();
+      expect(fieldSelectors.buttonSetDate()).toBeInTheDocument();
+
+      /**
+       * Set Date
+       */
+      await act(() => fireEvent.click(fieldSelectors.buttonSetDate()));
+
+      /**
+       * Date
+       */
+      expect(fieldSelectors.fieldDateTime()).toBeInTheDocument();
+
+      /**
+       * Change Date
+       */
+      const date = new Date('2021-07-31 12:30:30');
+      await act(() => fireEvent.change(fieldSelectors.fieldDateTime(), { target: { value: date.toISOString() } }));
+
+      expect(fieldSelectors.fieldDateTime()).toHaveValue(date.toISOString());
+
+      await act(() => fireEvent.click(selectors.buttonSaveChanges()));
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            min: date.toISOString(),
+          }),
+        ])
+      );
+
+      /**
+       * Remove Date
+       */
+      expect(fieldSelectors.buttonRemoveDate()).toBeInTheDocument();
+
+      await act(() => fireEvent.click(fieldSelectors.buttonRemoveDate()));
+
+      /**
+       * Date is not set
+       */
+      expect(fieldSelectors.fieldMinDate(true)).not.toBeInTheDocument();
+    });
+
     it('Should update Code Language', async () => {
       const element = {
         ...FormElementDefault,

--- a/src/constants/tests.ts
+++ b/src/constants/tests.ts
@@ -84,6 +84,9 @@ export const TestIds = {
     fieldUnit: 'data-testid form-elements-editor field-unit',
     fieldVisibility: 'data-testid form-elements-editor field-visibility',
     fieldWidth: 'data-testid form-elements-editor field-width',
+    fieldDateTime: 'date-time-input',
+    fieldMinDate: 'data-testid form-elements-editor field-min-date',
+    fieldMaxDate: 'data-testid form-elements-editor field-max-date',
     newElementId: 'data-testid form-elements-editor new-element-id',
     newElementLabel: 'data-testid form-elements-editor new-element-label',
     newElementType: 'form-elements-editor new-element-type',
@@ -93,6 +96,8 @@ export const TestIds = {
     sectionLabel: (id: string, type: string) => `data-testid form-elements-editor section-label-${id}-${type}`,
     sectionNewContent: 'data-testid form-elements-editor section-new-content',
     sectionNewLabel: 'data-testid form-elements-editor section-new-label',
+    buttonSetDate: 'data-testid form-elements-editor button-set-date',
+    buttonRemoveDate: 'data-testid form-elements-editor button-remove-date',
   },
   headerParametersEditor: {
     buttonAdd: 'data-testid header-parameters-editor button-add',

--- a/src/types/form-element.ts
+++ b/src/types/form-element.ts
@@ -175,9 +175,9 @@ export interface NumberOptions {
   /**
    * Value
    *
-   * @type {number}
+   * @type {number | null}
    */
-  value: number;
+  value: number | null;
 }
 
 /**
@@ -205,6 +205,26 @@ export interface SelectOptions {
 }
 
 /**
+ * Date Time Options
+ */
+export interface DateTimeOptions {
+  /**
+   * Min Date
+   */
+  min?: string;
+
+  /**
+   * Max Date
+   */
+  max?: string;
+
+  /**
+   * Value
+   */
+  value: string;
+}
+
+/**
  * Form Element
  */
 export type FormElement = FormElementBase &
@@ -219,7 +239,7 @@ export type FormElement = FormElementBase &
     | ({ type: FormElementType.RADIO } & SelectOptions)
     | ({ type: FormElementType.DISABLED } & SelectOptions)
     | { type: FormElementType.PASSWORD }
-    | { type: FormElementType.DATETIME }
+    | ({ type: FormElementType.DATETIME } & DateTimeOptions)
     | { type: FormElementType.SECRET }
     | { type: FormElementType.BOOLEAN }
   );

--- a/src/utils/form-element.ts
+++ b/src/utils/form-element.ts
@@ -87,6 +87,12 @@ export const GetElementWithNewType = (
         type: newType,
       };
     }
+    case FormElementType.DATETIME: {
+      return {
+        ...baseValues,
+        type: newType,
+      };
+    }
     default: {
       return {
         ...baseValues,
@@ -98,8 +104,8 @@ export const GetElementWithNewType = (
 
 /**
  * Is Element Conflict
- * @param elements<FormElement[]>
- * @param element<FormElement>
+ * @params elements<FormElement[]>
+ * @params element<FormElement>
  */
 export const IsElementConflict = (elements: FormElement[], element: FormElement) => {
   return elements.some((item) => item.id === element.id && item.type === element.type);
@@ -107,8 +113,8 @@ export const IsElementConflict = (elements: FormElement[], element: FormElement)
 
 /**
  * Is Element Option Conflict
- * @param options<SelectableValue[]>
- * @param option<SelectableValue>
+ * @params options<SelectableValue[]>
+ * @params option<SelectableValue>
  * @constructor
  */
 export const IsElementOptionConflict = (options: SelectableValue[], option: SelectableValue) => {

--- a/src/utils/form-element.ts
+++ b/src/utils/form-element.ts
@@ -87,12 +87,6 @@ export const GetElementWithNewType = (
         type: newType,
       };
     }
-    case FormElementType.DATETIME: {
-      return {
-        ...baseValues,
-        type: newType,
-      };
-    }
     default: {
       return {
         ...baseValues,

--- a/src/utils/tests.ts
+++ b/src/utils/tests.ts
@@ -14,7 +14,7 @@ export const getFormElementsSelectors = getJestSelectors(TestIds.formElements, [
 /**
  * Get Form Elements Editor Selectors
  */
-export const getFormElementsEditorSelectors = getJestSelectors(TestIds.formElementsEditor);
+export const getFormElementsEditorSelectors = getJestSelectors(TestIds.formElementsEditor, ['fieldDateTime']);
 
 /**
  * Get Panel Selectors


### PR DESCRIPTION
Resolves #173 

DateTimePicker doesn't support resetting value, so ElementDateEditor was added with add and remove buttons
<img width="612" alt="Screenshot 2023-08-15 at 12 36 21" src="https://github.com/VolkovLabs/volkovlabs-form-panel/assets/15867703/cb754c59-b381-4f04-ab27-9f8e8cf2cc94">
