### PR TITLE
Add backward compatibility for option id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 3.2.1 (2023-09-07)
+
+### Features / Enhancements
+
+- Add backward compatibility for option id (#244)
+
 ## 3.2.0 (2023-09-06)
 
 ### Features / Enhancements

--- a/package.json
+++ b/package.json
@@ -71,5 +71,5 @@
     "test:ci": "jest --maxWorkers 4 --coverage",
     "upgrade": "npm upgrade --save"
   },
-  "version": "3.2.0"
+  "version": "3.2.1"
 }

--- a/src/components/ElementOptionsEditor/ElementOptionsEditor.tsx
+++ b/src/components/ElementOptionsEditor/ElementOptionsEditor.tsx
@@ -180,6 +180,16 @@ export const ElementOptionsEditor: React.FC<Props> = ({ options = [], onChange, 
                                         true
                                       );
                                     }}
+                                    onBlur={() => {
+                                      const newId = option.value?.toString() || FormElementOptionDefault.id;
+                                      onChangeItem(
+                                        {
+                                          ...option,
+                                          id: newId,
+                                        },
+                                        option
+                                      );
+                                    }}
                                     value={option.value}
                                     data-testid={TestIds.formElementsEditor.fieldOptionValue}
                                   />

--- a/src/components/FormElementsEditor/FormElementsEditor.test.tsx
+++ b/src/components/FormElementsEditor/FormElementsEditor.test.tsx
@@ -1615,6 +1615,13 @@ describe('Form Elements Editor', () => {
       await act(() => fireEvent.change(optionSelectors.fieldOptionValue(), { target: { value: '123' } }));
 
       expect(optionSelectors.fieldOptionValue()).toHaveValue('123');
+
+      /**
+       * ID should be updated after lose focus
+       */
+      await act(() => fireEvent.blur(optionSelectors.fieldOptionValue()));
+
+      expect(elementSelectors.optionLabel(false, '123')).toBeInTheDocument();
     });
 
     it('Should update option value for NUMBER option', async () => {
@@ -1640,6 +1647,13 @@ describe('Form Elements Editor', () => {
       await act(() => fireEvent.change(optionSelectors.fieldOptionValue(), { target: { value: '123' } }));
 
       expect(optionSelectors.fieldOptionValue()).toHaveValue(123);
+
+      /**
+       * ID should be updated after lose focus
+       */
+      await act(() => fireEvent.blur(optionSelectors.fieldOptionValue()));
+
+      expect(elementSelectors.optionLabel(false, '123')).toBeInTheDocument();
     });
 
     it('Should use default option id if empty value', async () => {
@@ -1662,6 +1676,13 @@ describe('Form Elements Editor', () => {
       await act(() => fireEvent.change(optionSelectors.fieldOptionValue(), { target: { value: '' } }));
 
       expect(optionSelectors.fieldOptionValue()).toHaveValue('');
+
+      /**
+       * ID should be updated after lose focus
+       */
+      await act(() => fireEvent.blur(optionSelectors.fieldOptionValue()));
+
+      expect(elementSelectors.optionLabel(false, FormElementOptionDefault.id)).toBeInTheDocument();
     });
 
     it('Should update option label', async () => {

--- a/src/utils/form-element.ts
+++ b/src/utils/form-element.ts
@@ -160,6 +160,11 @@ export const GetElementUniqueId = (element: FormElement) => element.uid || uuidv
 export const GetLayoutUniqueId = (section: LayoutSection) => (section.id !== undefined ? section.id : section.name);
 
 /**
+ * Get Option Unique Id
+ */
+export const GetOptionUniqueId = (option: SelectableValue) => (option.id !== undefined ? option.id : option.value);
+
+/**
  * Is Section Collision Exists
  */
 export const IsSectionCollisionExists = (sections: LayoutSection[], compareWith: LayoutSection) => {
@@ -181,6 +186,14 @@ export const ToLocalFormElement = (element: FormElement): LocalFormElement => {
 
   return {
     ...element,
+    ...('options' in element
+      ? {
+          options: element.options?.map((option) => ({
+            ...option,
+            id: GetOptionUniqueId(option),
+          })),
+        }
+      : {}),
     helpers: {
       showIf: showIfFn,
     },


### PR DESCRIPTION
Updated options should contain id field to work correctly. Add function to assign values in id field if no specified