### PR TITLE
Add EventBus and AppEvents to Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add ability to disable panel syncing (#298)
 - Update ESLint configuration and refactor (#299)
 - Update Collapse from @volkovlabs/components (#299)
+- Add EventBus and AppEvents to Context (#307)
 
 ## 3.3.0 (2023-11-21)
 

--- a/src/components/FormPanel/FormPanel.tsx
+++ b/src/components/FormPanel/FormPanel.tsx
@@ -241,6 +241,7 @@ export const FormPanel: React.FC<Props> = ({
             notifyWarning,
             eventBus,
             appEvents,
+            refresh: () => appEvents.publish({ type: 'variables-changed', payload: { refreshAll: true } }),
           },
           panel: {
             options,

--- a/src/components/FormPanel/FormPanel.tsx
+++ b/src/components/FormPanel/FormPanel.tsx
@@ -239,6 +239,8 @@ export const FormPanel: React.FC<Props> = ({
             notifyError,
             notifySuccess,
             notifyWarning,
+            eventBus,
+            appEvents,
           },
           panel: {
             options,

--- a/src/constants/code-editor.ts
+++ b/src/constants/code-editor.ts
@@ -102,11 +102,19 @@ export const CODE_EDITOR_SUGGESTIONS: CodeEditorSuggestionItem[] = [
     kind: CodeEditorSuggestionItemKind.Method,
     detail: 'Parse the results from /api/ds/query.',
   },
+
+  /**
+   * Context
+   */
   {
     label: 'context',
     kind: CodeEditorSuggestionItemKind.Constant,
     detail: 'All passed possible properties and methods.',
   },
+
+  /**
+   * Panel
+   */
   {
     label: 'context.panel',
     kind: CodeEditorSuggestionItemKind.Property,
@@ -152,9 +160,63 @@ export const CODE_EDITOR_SUGGESTIONS: CodeEditorSuggestionItem[] = [
     kind: CodeEditorSuggestionItemKind.Property,
     detail: 'Response object.',
   },
+
+  /**
+   * Grafana
+   */
   {
     label: 'context.grafana',
     kind: CodeEditorSuggestionItemKind.Property,
     detail: 'Grafana properties and methods.',
+  },
+  {
+    label: 'context.grafana.locationService',
+    kind: CodeEditorSuggestionItemKind.Property,
+    detail: 'Location service.',
+  },
+  {
+    label: 'context.grafana.templateService',
+    kind: CodeEditorSuggestionItemKind.Property,
+    detail: 'Template variables service.',
+  },
+  {
+    label: 'context.grafana.notifyError',
+    kind: CodeEditorSuggestionItemKind.Method,
+    detail: 'Show error notification.',
+  },
+  {
+    label: 'context.grafana.notifySuccess',
+    kind: CodeEditorSuggestionItemKind.Method,
+    detail: 'Show success notification.',
+  },
+  {
+    label: 'context.grafana.notifyWarning',
+    kind: CodeEditorSuggestionItemKind.Method,
+    detail: 'Show warning notification.',
+  },
+  {
+    label: 'context.grafana.eventBus',
+    kind: CodeEditorSuggestionItemKind.Property,
+    detail: 'Panels events.',
+  },
+  {
+    label: 'context.grafana.appEvents',
+    kind: CodeEditorSuggestionItemKind.Property,
+    detail: 'Application events.',
+  },
+  {
+    label: 'context.grafana.refresh',
+    kind: CodeEditorSuggestionItemKind.Method,
+    detail: 'Refresh dashboard.',
+  },
+  {
+    label: 'context.utils',
+    kind: CodeEditorSuggestionItemKind.Property,
+    detail: 'Utils/helpers functions.',
+  },
+  {
+    label: 'context.utils.toDataQueryResponse',
+    kind: CodeEditorSuggestionItemKind.Method,
+    detail: 'Parse the results from /api/ds/query.',
   },
 ];


### PR DESCRIPTION
1. Add `eventBus` and `appEvents` to context.
2. Add `refresh` function to refresh dashboard.
3. Update `context.grafana` suggestions.

Refresh dashboard:
```
appEvents.publish({ type: 'variables-changed', payload: { refreshAll: true } });
```