### PR TITLE
Fix draggable control to support upcoming Grafana changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Add EventBus and AppEvents to Context (#307)
 - Add replacing variables in Payload functions (#309)
 
+### Bugfixes
+
+- Fix draggable control to support upcoming Grafana changes (#314)
+
 ## 3.3.0 (2023-11-21)
 
 ### Features / Enhancements

--- a/src/components/ElementOptionsEditor/ElementOptionsEditor.styles.ts
+++ b/src/components/ElementOptionsEditor/ElementOptionsEditor.styles.ts
@@ -13,10 +13,13 @@ export const getStyles = (theme: GrafanaTheme2) => {
     item: css`
       margin-bottom: ${theme.spacing(1)};
     `,
+    dragHandle: css`
+      display: flex;
+      margin: ${theme.spacing(0, 0.5)};
+    `,
     dragIcon: css`
       cursor: grab;
       color: ${theme.colors.text.disabled};
-      margin: ${theme.spacing(0, 0.5)};
       &:hover {
         color: ${theme.colors.text};
       }

--- a/src/components/ElementOptionsEditor/ElementOptionsEditor.tsx
+++ b/src/components/ElementOptionsEditor/ElementOptionsEditor.tsx
@@ -129,13 +129,14 @@ export const ElementOptionsEditor: React.FC<Props> = ({ options = [], onChange, 
                                   onClick={() => onChange(options?.filter((o) => o.id !== option.id))}
                                   aria-label="Remove"
                                 />
-                                <Icon
-                                  title="Drag and drop to reorder"
-                                  name="draggabledots"
-                                  size="lg"
-                                  className={styles.dragIcon}
-                                  {...provided.dragHandleProps}
-                                />
+                                <div className={styles.dragHandle} {...provided.dragHandleProps}>
+                                  <Icon
+                                    title="Drag and drop to reorder"
+                                    name="draggabledots"
+                                    size="lg"
+                                    className={styles.dragIcon}
+                                  />
+                                </div>
                               </>
                             }
                           >

--- a/src/components/FormElementsEditor/FormElementsEditor.styles.ts
+++ b/src/components/FormElementsEditor/FormElementsEditor.styles.ts
@@ -9,10 +9,13 @@ export const getStyles = (theme: GrafanaTheme2) => {
     item: css`
       margin-bottom: ${theme.spacing(1)};
     `,
+    dragHandle: css`
+      display: flex;
+      margin: ${theme.spacing(0, 0.5)};
+    `,
     dragIcon: css`
       cursor: grab;
       color: ${theme.colors.text.disabled};
-      margin: ${theme.spacing(0, 0.5)};
       &:hover {
         color: ${theme.colors.text};
       }

--- a/src/components/FormElementsEditor/FormElementsEditor.tsx
+++ b/src/components/FormElementsEditor/FormElementsEditor.tsx
@@ -151,13 +151,14 @@ export const FormElementsEditor: React.FC<Props> = ({ value, onChange, context }
                                 onClick={() => onElementRemove(getElementUniqueId(element))}
                                 aria-label="Remove"
                               />
-                              <Icon
-                                title="Drag and drop to reorder"
-                                name="draggabledots"
-                                size="lg"
-                                className={styles.dragIcon}
-                                {...provided.dragHandleProps}
-                              />
+                              <div className={styles.dragHandle} {...provided.dragHandleProps}>
+                                <Icon
+                                  title="Drag and drop to reorder"
+                                  name="draggabledots"
+                                  size="lg"
+                                  className={styles.dragIcon}
+                                />
+                              </div>
                             </>
                           }
                         >


### PR DESCRIPTION
Resolves #312 

The reason is this PR which removes div wrapping for the Icon component - https://github.com/grafana/grafana/pull/76819