### PR TITLE
Add update enabled option and variables examples, fix sync option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "volkovlabs-form-panel",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "volkovlabs-form-panel",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.11.2",

--- a/provisioning/dashboards/variables.json
+++ b/provisioning/dashboards/variables.json
@@ -1,0 +1,458 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "marcusolsson-static-datasource",
+        "uid": "P1D2C73DC01F2359B"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "buttonGroup": {
+          "orientation": "center",
+          "size": "md"
+        },
+        "confirmModal": {
+          "body": "Please confirm to update changed values",
+          "cancel": "Cancel",
+          "columns": {
+            "name": "Label",
+            "newValue": "New Value",
+            "oldValue": "Old Value"
+          },
+          "confirm": "Confirm",
+          "title": "Confirm update request"
+        },
+        "elementValueChanged": "if (context.element.id === 'facility') {\n  context.grafana.locationService.partial({\n    'var-facility': context.element.value,\n  });\n}\n\nif (context.element.id === 'room') {\n  context.grafana.locationService.partial({\n    'var-room': context.element.value,\n  });\n}\n\nif (context.element.id === 'bench') {\n  context.grafana.locationService.partial({\n    'var-bench': context.element.value,\n  });\n}",
+        "elements": [
+          {
+            "getOptions": "",
+            "id": "facility",
+            "labelWidth": 20,
+            "options": [],
+            "optionsSource": "Query",
+            "queryField": {
+              "label": "Initial Values:facility",
+              "refId": "Initial Values",
+              "value": "facility"
+            },
+            "queryOptions": {
+              "label": "label",
+              "source": "Facility Options",
+              "value": "value"
+            },
+            "section": "",
+            "showIf": "",
+            "title": "Facility Name",
+            "tooltip": "",
+            "type": "select",
+            "uid": "5b149377-ab7f-401a-be7c-f3aabf7ff7d2",
+            "unit": "",
+            "value": ""
+          },
+          {
+            "id": "room",
+            "labelWidth": 20,
+            "options": [],
+            "optionsSource": "Query",
+            "queryField": {
+              "label": "Initial Values:room",
+              "refId": "Initial Values",
+              "value": "room"
+            },
+            "queryOptions": {
+              "label": "label",
+              "source": "Room Options",
+              "value": "value"
+            },
+            "section": "",
+            "title": "Room Name",
+            "tooltip": "",
+            "type": "select",
+            "uid": "3faf7e1d-90a4-4269-9555-97d18abed23f",
+            "unit": "",
+            "value": ""
+          },
+          {
+            "id": "bench",
+            "labelWidth": 20,
+            "options": [],
+            "optionsSource": "Query",
+            "queryField": {
+              "label": "Initial Values:bench",
+              "refId": "Initial Values",
+              "value": "bench"
+            },
+            "queryOptions": {
+              "label": "label",
+              "source": "Bench Options",
+              "value": "value"
+            },
+            "section": "",
+            "title": "Bench Name",
+            "tooltip": "",
+            "type": "select",
+            "uid": "29b3bbbd-d00c-45b4-a8f9-1883b416af3b",
+            "unit": "",
+            "value": ""
+          }
+        ],
+        "initial": {
+          "code": "",
+          "contentType": "application/json",
+          "getPayload": "return {\n  rawSql: '',\n  format: 'table',\n}",
+          "highlight": false,
+          "highlightColor": "red",
+          "method": "query"
+        },
+        "layout": {
+          "orientation": "horizontal",
+          "padding": 10,
+          "variant": "single"
+        },
+        "reset": {
+          "backgroundColor": "purple",
+          "foregroundColor": "yellow",
+          "icon": "process",
+          "text": "Reset",
+          "variant": "hidden"
+        },
+        "resetAction": {
+          "code": "if (response && response.ok) {\n  notifySuccess(['Update', 'Values updated successfully.']);\n  locationService.reload();\n} else {\n  notifyError(['Update', 'An error occured updating values.']);\n}",
+          "confirm": false,
+          "getPayload": "return {\n  rawSql: '',\n  format: 'table',\n}",
+          "mode": "initial"
+        },
+        "saveDefault": {
+          "icon": "save",
+          "text": "Save Default",
+          "variant": "hidden"
+        },
+        "submit": {
+          "backgroundColor": "purple",
+          "foregroundColor": "yellow",
+          "icon": "cloud-upload",
+          "text": "Submit",
+          "variant": "primary"
+        },
+        "sync": true,
+        "update": {
+          "code": "if (response && response.ok) {\n  notifySuccess(['Update', 'Values updated successfully.']);\n  locationService.reload();\n} else {\n  notifyError(['Update', 'An error occured updating values.']);\n}",
+          "confirm": false,
+          "contentType": "application/json",
+          "getPayload": "const payload = {};\n\nelements.forEach((element) => {\n  if (!element.value) {\n    return;\n  }\n\n  payload[element.id] = element.value;\n})\n\nreturn payload;\n\n/**\n * Data Source payload\n */ \nreturn {\n  rawSql: '',\n  format: 'table',\n};",
+          "method": "-",
+          "payloadMode": "all"
+        }
+      },
+      "pluginVersion": "3.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "marcusolsson-static-datasource",
+            "uid": "P1D2C73DC01F2359B"
+          },
+          "frame": {
+            "fields": [
+              {
+                "config": {},
+                "name": "value",
+                "type": "string",
+                "values": [
+                  "facility1",
+                  "facility2",
+                  "facility3"
+                ]
+              },
+              {
+                "config": {},
+                "name": "label",
+                "type": "string",
+                "values": [
+                  "facility1",
+                  "facility2",
+                  "facility3"
+                ]
+              }
+            ],
+            "meta": {},
+            "name": "facilities"
+          },
+          "hide": false,
+          "refId": "Facility Options"
+        },
+        {
+          "datasource": {
+            "type": "marcusolsson-static-datasource",
+            "uid": "P1D2C73DC01F2359B"
+          },
+          "frame": {
+            "fields": [
+              {
+                "config": {},
+                "name": "label",
+                "type": "string",
+                "values": [
+                  "$facility-room1",
+                  "$facility-room2"
+                ]
+              },
+              {
+                "config": {},
+                "name": "value",
+                "type": "string",
+                "values": [
+                  "$facility-room1",
+                  "$facility-room2"
+                ]
+              }
+            ],
+            "meta": {},
+            "name": "rooms"
+          },
+          "refId": "Room Options"
+        },
+        {
+          "datasource": {
+            "type": "marcusolsson-static-datasource",
+            "uid": "P1D2C73DC01F2359B"
+          },
+          "frame": {
+            "fields": [
+              {
+                "config": {},
+                "name": "value",
+                "type": "string",
+                "values": [
+                  "$room-bench1",
+                  "$room-bench2"
+                ]
+              },
+              {
+                "config": {},
+                "name": "label",
+                "type": "string",
+                "values": [
+                  "$room-bench1",
+                  "$room-bench2"
+                ]
+              }
+            ],
+            "meta": {}
+          },
+          "hide": false,
+          "refId": "Bench Options"
+        },
+        {
+          "datasource": {
+            "type": "marcusolsson-static-datasource",
+            "uid": "P1D2C73DC01F2359B"
+          },
+          "frame": {
+            "fields": [
+              {
+                "config": {},
+                "name": "facility",
+                "type": "string",
+                "values": [
+                  "$facility"
+                ]
+              },
+              {
+                "config": {},
+                "name": "room",
+                "type": "string",
+                "values": [
+                  "$room"
+                ]
+              },
+              {
+                "config": {},
+                "name": "bench",
+                "type": "string",
+                "values": [
+                  "$bench"
+                ]
+              }
+            ],
+            "meta": {},
+            "name": "values"
+          },
+          "hide": false,
+          "refId": "Initial Values"
+        }
+      ],
+      "title": "Panel Title",
+      "type": "volkovlabs-form-panel"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "facility1",
+          "value": "facility1"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "facility",
+        "options": [
+          {
+            "selected": true,
+            "text": "facility1",
+            "value": "facility1"
+          },
+          {
+            "selected": false,
+            "text": "facility2",
+            "value": "facility2"
+          },
+          {
+            "selected": false,
+            "text": "facility3",
+            "value": "facility3"
+          }
+        ],
+        "query": "facility1, facility2, facility3",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "facility1-room1",
+          "value": "facility1-room1"
+        },
+        "datasource": {
+          "type": "marcusolsson-static-datasource",
+          "uid": "P1D2C73DC01F2359B"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "room",
+        "options": [],
+        "query": {
+          "frame": {
+            "fields": [
+              {
+                "config": {},
+                "name": "value",
+                "type": "string",
+                "values": [
+                  "$facility-room1",
+                  "$facility-room2"
+                ]
+              },
+              {
+                "config": {},
+                "name": "label",
+                "type": "string",
+                "values": [
+                  "$facility-room1",
+                  "$facility-room2"
+                ]
+              }
+            ],
+            "meta": {}
+          }
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "facility1-room1-bench1",
+          "value": "facility1-room1-bench1"
+        },
+        "datasource": {
+          "type": "marcusolsson-static-datasource",
+          "uid": "P1D2C73DC01F2359B"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "bench",
+        "options": [],
+        "query": {
+          "frame": {
+            "fields": [
+              {
+                "config": {},
+                "name": "value",
+                "type": "string",
+                "values": [
+                  "$room-bench1",
+                  "$room-bench2"
+                ]
+              },
+              {
+                "config": {},
+                "name": "label",
+                "type": "string",
+                "values": [
+                  "$room-bench1",
+                  "$room-bench2"
+                ]
+              }
+            ],
+            "meta": {}
+          }
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Variables",
+  "uid": "c63788ef-96f5-4d2b-a52d-e18c91053233",
+  "version": 14,
+  "weekStart": ""
+}

--- a/provisioning/dashboards/variables.json
+++ b/provisioning/dashboards/variables.json
@@ -49,7 +49,7 @@
           "confirm": "Confirm",
           "title": "Confirm update request"
         },
-        "elementValueChanged": "if (context.element.id === 'facility') {\n  context.grafana.locationService.partial({\n    'var-facility': context.element.value,\n  });\n}\n\nif (context.element.id === 'room') {\n  context.grafana.locationService.partial({\n    'var-room': context.element.value,\n  });\n}\n\nif (context.element.id === 'bench') {\n  context.grafana.locationService.partial({\n    'var-bench': context.element.value,\n  });\n}",
+        "elementValueChanged": "if (context.element.id === 'facility') {\n  context.grafana.locationService.partial({\n    'var-facility': context.element.value,\n  });\n}\n\nif (context.element.id === 'room') {\n  context.grafana.locationService.partial({\n    'var-room': context.element.value,\n  });\n}\n\nif (context.element.id === 'bench') {\n  context.grafana.locationService.partial({\n    'var-bench': context.element.value,\n  });\n}\n\ncontext.panel.enableSubmit();",
         "elements": [
           {
             "getOptions": "",
@@ -169,7 +169,8 @@
           "getPayload": "const payload = {};\n\nelements.forEach((element) => {\n  if (!element.value) {\n    return;\n  }\n\n  payload[element.id] = element.value;\n})\n\nreturn payload;\n\n/**\n * Data Source payload\n */ \nreturn {\n  rawSql: '',\n  format: 'table',\n};",
           "method": "-",
           "payloadMode": "all"
-        }
+        },
+        "updateEnabled": "manual"
       },
       "pluginVersion": "3.6.0",
       "targets": [
@@ -308,7 +309,310 @@
           "refId": "Initial Values"
         }
       ],
-      "title": "Panel Title",
+      "title": "Variables only",
+      "type": "volkovlabs-form-panel"
+    },
+    {
+      "datasource": {
+        "type": "marcusolsson-static-datasource",
+        "uid": "P1D2C73DC01F2359B"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "buttonGroup": {
+          "orientation": "center",
+          "size": "md"
+        },
+        "confirmModal": {
+          "body": "Please confirm to update changed values",
+          "cancel": "Cancel",
+          "columns": {
+            "name": "Label",
+            "newValue": "New Value",
+            "oldValue": "Old Value"
+          },
+          "confirm": "Confirm",
+          "title": "Confirm update request"
+        },
+        "elementValueChanged": "if (context.element.id === 'facility') {\n  context.grafana.locationService.partial({\n    'var-facility': context.element.value,\n  });\n}\n\nif (context.element.id === 'room') {\n  context.grafana.locationService.partial({\n    'var-room': context.element.value,\n  });\n}\n\nif (context.element.id === 'bench') {\n  context.grafana.locationService.partial({\n    'var-bench': context.element.value,\n  });\n}\n\ncontext.panel.enableSubmit();",
+        "elements": [
+          {
+            "getOptions": "",
+            "id": "facility",
+            "labelWidth": 20,
+            "options": [],
+            "optionsSource": "Query",
+            "queryField": {
+              "label": "Initial Values:facility",
+              "refId": "Initial Values",
+              "value": "facility"
+            },
+            "queryOptions": {
+              "label": "label",
+              "source": "Facility Options",
+              "value": "value"
+            },
+            "section": "",
+            "showIf": "",
+            "title": "Facility Name",
+            "tooltip": "",
+            "type": "select",
+            "uid": "5b149377-ab7f-401a-be7c-f3aabf7ff7d2",
+            "unit": "",
+            "value": ""
+          },
+          {
+            "id": "room",
+            "labelWidth": 20,
+            "options": [],
+            "optionsSource": "Query",
+            "queryField": {
+              "label": "Initial Values:room",
+              "refId": "Initial Values",
+              "value": "room"
+            },
+            "queryOptions": {
+              "label": "label",
+              "source": "Room Options",
+              "value": "value"
+            },
+            "section": "",
+            "title": "Room Name",
+            "tooltip": "",
+            "type": "select",
+            "uid": "3faf7e1d-90a4-4269-9555-97d18abed23f",
+            "unit": "",
+            "value": ""
+          },
+          {
+            "id": "bench",
+            "labelWidth": 20,
+            "options": [],
+            "optionsSource": "Query",
+            "queryField": {
+              "label": "Initial Values:bench",
+              "refId": "Initial Values",
+              "value": "bench"
+            },
+            "queryOptions": {
+              "label": "label",
+              "source": "Bench Options",
+              "value": "value"
+            },
+            "section": "",
+            "title": "Bench Name",
+            "tooltip": "",
+            "type": "select",
+            "uid": "29b3bbbd-d00c-45b4-a8f9-1883b416af3b",
+            "unit": "",
+            "value": ""
+          },
+          {
+            "id": "comment",
+            "labelWidth": 20,
+            "rows": 4,
+            "section": "",
+            "title": "Comment",
+            "tooltip": "",
+            "type": "textarea",
+            "uid": "0084c822-3745-4775-8172-392ca4d8daeb",
+            "unit": "",
+            "value": ""
+          }
+        ],
+        "initial": {
+          "code": "",
+          "contentType": "application/json",
+          "getPayload": "return {\n  rawSql: '',\n  format: 'table',\n}",
+          "highlight": false,
+          "highlightColor": "red",
+          "method": "query"
+        },
+        "layout": {
+          "orientation": "horizontal",
+          "padding": 10,
+          "variant": "single"
+        },
+        "reset": {
+          "backgroundColor": "purple",
+          "foregroundColor": "yellow",
+          "icon": "process",
+          "text": "Reset",
+          "variant": "hidden"
+        },
+        "resetAction": {
+          "code": "if (response && response.ok) {\n  notifySuccess(['Update', 'Values updated successfully.']);\n  locationService.reload();\n} else {\n  notifyError(['Update', 'An error occured updating values.']);\n}",
+          "confirm": false,
+          "getPayload": "return {\n  rawSql: '',\n  format: 'table',\n}",
+          "mode": "initial"
+        },
+        "saveDefault": {
+          "icon": "save",
+          "text": "Save Default",
+          "variant": "hidden"
+        },
+        "submit": {
+          "backgroundColor": "purple",
+          "foregroundColor": "yellow",
+          "icon": "cloud-upload",
+          "text": "Submit",
+          "variant": "primary"
+        },
+        "sync": true,
+        "update": {
+          "code": "if (response && response.ok) {\n  notifySuccess(['Update', 'Values updated successfully.']);\n  locationService.reload();\n} else {\n  notifyError(['Update', 'An error occured updating values.']);\n}",
+          "confirm": false,
+          "contentType": "application/json",
+          "getPayload": "const payload = {};\n\nelements.forEach((element) => {\n  if (!element.value) {\n    return;\n  }\n\n  payload[element.id] = element.value;\n})\n\nreturn payload;\n\n/**\n * Data Source payload\n */ \nreturn {\n  rawSql: '',\n  format: 'table',\n};",
+          "method": "-",
+          "payloadMode": "all"
+        },
+        "updateEnabled": "manual"
+      },
+      "pluginVersion": "3.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "marcusolsson-static-datasource",
+            "uid": "P1D2C73DC01F2359B"
+          },
+          "frame": {
+            "fields": [
+              {
+                "config": {},
+                "name": "value",
+                "type": "string",
+                "values": [
+                  "facility1",
+                  "facility2",
+                  "facility3"
+                ]
+              },
+              {
+                "config": {},
+                "name": "label",
+                "type": "string",
+                "values": [
+                  "facility1",
+                  "facility2",
+                  "facility3"
+                ]
+              }
+            ],
+            "meta": {},
+            "name": "facilities"
+          },
+          "hide": false,
+          "refId": "Facility Options"
+        },
+        {
+          "datasource": {
+            "type": "marcusolsson-static-datasource",
+            "uid": "P1D2C73DC01F2359B"
+          },
+          "frame": {
+            "fields": [
+              {
+                "config": {},
+                "name": "label",
+                "type": "string",
+                "values": [
+                  "$facility-room1",
+                  "$facility-room2"
+                ]
+              },
+              {
+                "config": {},
+                "name": "value",
+                "type": "string",
+                "values": [
+                  "$facility-room1",
+                  "$facility-room2"
+                ]
+              }
+            ],
+            "meta": {},
+            "name": "rooms"
+          },
+          "refId": "Room Options"
+        },
+        {
+          "datasource": {
+            "type": "marcusolsson-static-datasource",
+            "uid": "P1D2C73DC01F2359B"
+          },
+          "frame": {
+            "fields": [
+              {
+                "config": {},
+                "name": "value",
+                "type": "string",
+                "values": [
+                  "$room-bench1",
+                  "$room-bench2"
+                ]
+              },
+              {
+                "config": {},
+                "name": "label",
+                "type": "string",
+                "values": [
+                  "$room-bench1",
+                  "$room-bench2"
+                ]
+              }
+            ],
+            "meta": {}
+          },
+          "hide": false,
+          "refId": "Bench Options"
+        },
+        {
+          "datasource": {
+            "type": "marcusolsson-static-datasource",
+            "uid": "P1D2C73DC01F2359B"
+          },
+          "frame": {
+            "fields": [
+              {
+                "config": {},
+                "name": "facility",
+                "type": "string",
+                "values": [
+                  "$facility"
+                ]
+              },
+              {
+                "config": {},
+                "name": "room",
+                "type": "string",
+                "values": [
+                  "$room"
+                ]
+              },
+              {
+                "config": {},
+                "name": "bench",
+                "type": "string",
+                "values": [
+                  "$bench"
+                ]
+              }
+            ],
+            "meta": {},
+            "name": "values"
+          },
+          "hide": false,
+          "refId": "Initial Values"
+        }
+      ],
+      "title": "With additional fields",
       "type": "volkovlabs-form-panel"
     }
   ],
@@ -320,8 +624,8 @@
       {
         "current": {
           "selected": false,
-          "text": "facility1",
-          "value": "facility1"
+          "text": "facility2",
+          "value": "facility2"
         },
         "hide": 0,
         "includeAll": false,
@@ -329,12 +633,12 @@
         "name": "facility",
         "options": [
           {
-            "selected": true,
+            "selected": false,
             "text": "facility1",
             "value": "facility1"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "facility2",
             "value": "facility2"
           },
@@ -352,8 +656,8 @@
       {
         "current": {
           "selected": false,
-          "text": "facility1-room1",
-          "value": "facility1-room1"
+          "text": "facility2-room2",
+          "value": "facility2-room2"
         },
         "datasource": {
           "type": "marcusolsson-static-datasource",
@@ -399,8 +703,8 @@
       {
         "current": {
           "selected": false,
-          "text": "facility1-room1-bench1",
-          "value": "facility1-room1-bench1"
+          "text": "facility2-room2-bench2",
+          "value": "facility2-room2-bench2"
         },
         "datasource": {
           "type": "marcusolsson-static-datasource",
@@ -453,6 +757,6 @@
   "timezone": "",
   "title": "Variables",
   "uid": "c63788ef-96f5-4d2b-a52d-e18c91053233",
-  "version": 14,
+  "version": 18,
   "weekStart": ""
 }

--- a/src/components/FormPanel/FormPanel.tsx
+++ b/src/components/FormPanel/FormPanel.tsx
@@ -42,7 +42,7 @@ import {
   ResetActionMode,
   TEST_IDS,
 } from '../../constants';
-import { useDatasourceRequest, useFormElements } from '../../hooks';
+import { useDatasourceRequest, useFormElements, useMutableState } from '../../hooks';
 import { ButtonVariant, FormElement, LocalFormElement, PanelOptions, UpdateEnabledMode } from '../../types';
 import {
   convertToElementValue,
@@ -79,7 +79,7 @@ export const FormPanel: React.FC<Props> = ({
   const [loading, setLoading] = useState<LoadingMode>(LoadingMode.INITIAL);
   const [error, setError] = useState('');
   const [title, setTitle] = useState('');
-  const [initial, setInitial] = useState<{ [id: string]: unknown }>({});
+  const [initial, setInitial, initialRef] = useMutableState<{ [id: string]: unknown }>({});
   const [updateConfirmation, setUpdateConfirmation] = useState(false);
   const [resetConfirmation, setResetConfirmation] = useState(false);
   const [isInitialized, setInitialized] = useState(false);
@@ -126,6 +126,7 @@ export const FormPanel: React.FC<Props> = ({
     onChangeElements,
     onSaveUpdates,
     eventBus: elementsEventBus,
+    elementsRef,
   } = useFormElements({
     onChange: onChangeOptions,
     value: options.elements,
@@ -168,7 +169,7 @@ export const FormPanel: React.FC<Props> = ({
       /**
        * Get elements values
        */
-      return elements.map((element): LocalFormElement => {
+      return elementsRef.current.map((element): LocalFormElement => {
         const fieldConfig = sourceType === RequestMethod.QUERY ? element.queryField : { value: element.fieldName };
         const field = frames
           .filter((frame) => (fieldConfig?.refId ? frame.refId === fieldConfig.refId : true))
@@ -192,113 +193,131 @@ export const FormPanel: React.FC<Props> = ({
         return element;
       });
     },
-    [elements]
+    [elementsRef]
   );
 
   /**
    * Execute Custom Code
    */
-  const executeCustomCode = async ({
-    code,
-    initial,
-    response,
-    initialRequest,
-    currentElements,
-  }: {
-    code: string;
-    initial: unknown;
-    response?: FetchResponse | Response | null;
-    initialRequest?: () => void;
-    currentElements?: LocalFormElement[];
-  }) => {
-    if (!code) {
-      return;
-    }
-
-    /**
-     * Function
-     */
-    const f = new Function(
-      'options',
-      'data',
-      'response',
-      'elements',
-      'onChange',
-      'locationService',
-      'templateService',
-      'onOptionsChange',
-      'initialRequest',
-      'setInitial',
-      'json',
-      'initial',
-      'notifyError',
-      'notifySuccess',
-      'notifyWarning',
-      'toDataQueryResponse',
-      'context',
-      replaceVariables(code)
-    );
-
-    try {
-      await f(
-        options,
-        data,
-        response,
-        currentElements || elements,
-        onChangeElements,
-        locationService,
-        templateSrv,
-        onOptionsChange,
-        initialRequest,
-        setInitial,
-        initial,
-        initial,
-        notifyError,
-        notifySuccess,
-        notifyWarning,
-        toDataQueryResponse,
-        {
-          grafana: {
-            locationService,
-            templateService: templateSrv,
-            notifyError,
-            notifySuccess,
-            notifyWarning,
-            eventBus,
-            appEvents,
-            refresh: () => appEvents.publish({ type: 'variables-changed', payload: { refreshAll: true } }),
-            backendService: getBackendSrv(),
-          },
-          panel: {
-            options,
-            data,
-            onOptionsChange,
-            elements: currentElements || elements,
-            onChangeElements,
-            setInitial,
-            initial,
-            initialRequest,
-            response,
-            enableSubmit: () => setSubmitEnabled(true),
-            disableSubmit: () => setSubmitEnabled(false),
-          },
-          utils: {
-            toDataQueryResponse,
-            fileToBase64,
-          },
-        }
-      );
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        setError(error.toString());
+  const executeCustomCode = useCallback(
+    async ({
+      code,
+      initial,
+      response,
+      initialRequest,
+      currentElements,
+    }: {
+      code: string;
+      initial: unknown;
+      response?: FetchResponse | Response | null;
+      initialRequest?: () => void;
+      currentElements?: LocalFormElement[];
+    }) => {
+      if (!code) {
+        return;
       }
-    }
-  };
+
+      /**
+       * Function
+       */
+      const f = new Function(
+        'options',
+        'data',
+        'response',
+        'elements',
+        'onChange',
+        'locationService',
+        'templateService',
+        'onOptionsChange',
+        'initialRequest',
+        'setInitial',
+        'json',
+        'initial',
+        'notifyError',
+        'notifySuccess',
+        'notifyWarning',
+        'toDataQueryResponse',
+        'context',
+        replaceVariables(code)
+      );
+
+      try {
+        await f(
+          options,
+          data,
+          response,
+          currentElements || elementsRef.current,
+          onChangeElements,
+          locationService,
+          templateSrv,
+          onOptionsChange,
+          initialRequest,
+          setInitial,
+          initialRef.current,
+          initialRef.current,
+          notifyError,
+          notifySuccess,
+          notifyWarning,
+          toDataQueryResponse,
+          {
+            grafana: {
+              locationService,
+              templateService: templateSrv,
+              notifyError,
+              notifySuccess,
+              notifyWarning,
+              eventBus,
+              appEvents,
+              refresh: () => appEvents.publish({ type: 'variables-changed', payload: { refreshAll: true } }),
+              backendService: getBackendSrv(),
+            },
+            panel: {
+              options,
+              data,
+              onOptionsChange,
+              elements: currentElements || elementsRef.current,
+              onChangeElements,
+              setInitial,
+              initial,
+              initialRequest,
+              response,
+              enableSubmit: () => setSubmitEnabled(true),
+              disableSubmit: () => setSubmitEnabled(false),
+            },
+            utils: {
+              toDataQueryResponse,
+              fileToBase64,
+            },
+          }
+        );
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          setError(error.toString());
+        }
+      }
+    },
+    [
+      replaceVariables,
+      options,
+      data,
+      elementsRef,
+      onChangeElements,
+      templateSrv,
+      onOptionsChange,
+      setInitial,
+      initialRef,
+      notifyError,
+      notifySuccess,
+      notifyWarning,
+      eventBus,
+      appEvents,
+    ]
+  );
 
   /**
    * Initial Request
    */
-  const initialRequest = async () => {
+  const initialRequest = useCallback(async () => {
     /**
      * Clear Error
      */
@@ -309,10 +328,10 @@ export const FormPanel: React.FC<Props> = ({
      */
     setLoading(LoadingMode.INITIAL);
 
-    let currentElements = elements;
+    let currentElements = elementsRef.current;
 
     if (
-      !elements.length ||
+      !elementsRef.current.length ||
       options.initial.method === RequestMethod.NONE ||
       options.initial.method === RequestMethod.QUERY
     ) {
@@ -332,7 +351,7 @@ export const FormPanel: React.FC<Props> = ({
       /**
        * No method specified
        */
-      await executeCustomCode({ code: options.initial.code, initial, currentElements });
+      await executeCustomCode({ code: options.initial.code, initial: initialRef.current, currentElements });
 
       /**
        * Reset Loading
@@ -367,8 +386,8 @@ export const FormPanel: React.FC<Props> = ({
           ...options.initial,
           payloadMode: PayloadMode.CUSTOM,
         },
-        elements,
-        initial,
+        elements: elementsRef.current,
+        initial: initialRef.current,
         replaceVariables,
       });
 
@@ -469,7 +488,7 @@ export const FormPanel: React.FC<Props> = ({
             };
           }, {}) || {};
 
-        currentElements = elements.map(
+        currentElements = elementsRef.current.map(
           (element): LocalFormElement => convertToElementValue(element, valuesMap[element.id])
         );
 
@@ -488,12 +507,24 @@ export const FormPanel: React.FC<Props> = ({
      */
     await executeCustomCode({ code: options.initial.code, initial: json, response, currentElements });
     setLoading(LoadingMode.NONE);
-  };
+  }, [
+    data.series,
+    datasourceRequest,
+    elementsRef,
+    executeCustomCode,
+    getElementsWithFieldValues,
+    initialRef,
+    onChangeElements,
+    options.elements,
+    options.initial,
+    replaceVariables,
+    setInitial,
+  ]);
 
   /**
    * Reset Request
    */
-  const resetRequest = async () => {
+  const resetRequest = useCallback(async () => {
     /**
      * Clear Error
      */
@@ -516,7 +547,7 @@ export const FormPanel: React.FC<Props> = ({
       /**
        * Execute Custom Code and reset Loading
        */
-      await executeCustomCode({ code: options.resetAction.code, initial });
+      await executeCustomCode({ code: options.resetAction.code, initial: initialRef.current });
       setLoading(LoadingMode.NONE);
     }
 
@@ -552,8 +583,8 @@ export const FormPanel: React.FC<Props> = ({
         highlightColor: '',
         confirm: false,
       },
-      elements,
-      initial,
+      elements: elementsRef.current,
+      initial: initialRef.current,
       replaceVariables,
     });
 
@@ -569,7 +600,7 @@ export const FormPanel: React.FC<Props> = ({
       return null;
     });
 
-    let currentElements = elements;
+    let currentElements = elementsRef.current;
     if (response && response.ok) {
       /**
        * Change Elements With Data Source Values
@@ -586,14 +617,27 @@ export const FormPanel: React.FC<Props> = ({
     /**
      * Execute Custom Code and reset Loading
      */
-    await executeCustomCode({ code: options.resetAction.code, initial, response, currentElements });
+    await executeCustomCode({ code: options.resetAction.code, initial: initialRef.current, response, currentElements });
     setLoading(LoadingMode.NONE);
-  };
+  }, [
+    datasourceRequest,
+    elementsRef,
+    executeCustomCode,
+    getElementsWithFieldValues,
+    initialRef,
+    initialRequest,
+    onChangeElements,
+    options.resetAction.code,
+    options.resetAction.datasource,
+    options.resetAction.getPayload,
+    options.resetAction.mode,
+    replaceVariables,
+  ]);
 
   /**
    * Update Request
    */
-  const updateRequest = async () => {
+  const updateRequest = useCallback(async () => {
     /**
      * Clear Error
      */
@@ -611,7 +655,7 @@ export const FormPanel: React.FC<Props> = ({
       /**
        * Execute Custom Code and reset Loading
        */
-      await executeCustomCode({ code: options.update.code, initial, initialRequest });
+      await executeCustomCode({ code: options.update.code, initial: initialRef.current, initialRequest });
       setLoading(LoadingMode.NONE);
 
       return;
@@ -623,7 +667,7 @@ export const FormPanel: React.FC<Props> = ({
     const payload = await getPayloadForRequest({
       request: options.update,
       elements,
-      initial,
+      initial: initialRef.current,
       replaceVariables,
     });
 
@@ -701,9 +745,9 @@ export const FormPanel: React.FC<Props> = ({
     /**
      * Execute Custom Code and reset Loading
      */
-    await executeCustomCode({ code: options.update.code, initial, response, initialRequest });
+    await executeCustomCode({ code: options.update.code, initial: initialRef.current, response, initialRequest });
     setLoading(LoadingMode.NONE);
-  };
+  }, [datasourceRequest, elements, executeCustomCode, initialRef, initialRequest, options.update, replaceVariables]);
 
   /**
    * Execute Initial Request on dashboard or data update
@@ -735,8 +779,7 @@ export const FormPanel: React.FC<Props> = ({
     return () => {
       subscriber.unsubscribe();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [options.initial, data, options.sync, isInitialized, eventBus]);
+  }, [options.initial, options.sync, eventBus, data.state, isInitialized, initialRequest]);
 
   /**
    * Check updated values
@@ -791,7 +834,7 @@ export const FormPanel: React.FC<Props> = ({
           onOptionsChange,
           elements,
           onChangeElements,
-          initial,
+          initial: initialRef.current,
           setError,
           enableReset: () => setResetEnabled(true),
           disableReset: () => setResetEnabled(false),
@@ -809,7 +852,7 @@ export const FormPanel: React.FC<Props> = ({
       appEvents,
       data,
       eventBus,
-      initial,
+      initialRef,
       notifyError,
       notifySuccess,
       notifyWarning,

--- a/src/constants/code-editor.ts
+++ b/src/constants/code-editor.ts
@@ -165,6 +165,16 @@ const BASE_CONTEXT_SUGGESTIONS: CodeEditorSuggestionItem[] = [
     kind: CodeEditorSuggestionItemKind.Property,
     detail: 'Response object.',
   },
+  {
+    label: 'context.panel.enableSubmit',
+    kind: CodeEditorSuggestionItemKind.Method,
+    detail: 'Enable submit button.',
+  },
+  {
+    label: 'context.panel.disableSubmit',
+    kind: CodeEditorSuggestionItemKind.Method,
+    detail: 'Disable submit button.',
+  },
 
   /**
    * Grafana

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -1,5 +1,7 @@
 import { SelectableValue } from '@grafana/data';
 
+import { UpdateEnabledMode } from '../types';
+
 /**
  * Request Methods
  */
@@ -122,4 +124,24 @@ export const RESET_ACTION_OPTIONS = [
   { label: 'Code', value: ResetActionMode.CUSTOM, icon: 'calculator-alt' },
   { label: 'Initial Request', value: ResetActionMode.INITIAL },
   { label: 'Data Source', value: ResetActionMode.DATASOURCE, icon: 'database' },
+];
+
+/**
+ * Update Enabled Options
+ */
+export const UPDATE_ENABLED_OPTIONS = [
+  {
+    value: UpdateEnabledMode.DISABLED,
+    label: 'Disabled',
+  },
+  {
+    value: UpdateEnabledMode.AUTO,
+    label: 'If Changed',
+    description: 'Enabled if value is changed from initial.',
+  },
+  {
+    value: UpdateEnabledMode.MANUAL,
+    label: 'Manual',
+    description: 'Disabled by default. Control through the code.',
+  },
 ];

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,4 +2,5 @@ export * from './useAutoSave';
 export * from './useDatasourceRequest';
 export * from './useDatasources';
 export * from './useFormElements';
+export * from './useMutableState';
 export * from './useQueryFields';

--- a/src/hooks/useMutableState.ts
+++ b/src/hooks/useMutableState.ts
@@ -1,0 +1,19 @@
+import { MutableRefObject, useCallback, useRef, useState } from 'react';
+
+/**
+ * Use Mutable State
+ * @param initialValue
+ */
+export const useMutableState = <TValue>(
+  initialValue: TValue
+): [TValue, (value: TValue) => void, MutableRefObject<TValue>] => {
+  const [value, setValue] = useState(initialValue);
+  const valueRef = useRef<TValue>(value);
+
+  const onChange = useCallback((value: TValue) => {
+    setValue(value);
+    valueRef.current = value;
+  }, []);
+
+  return [value, onChange, valueRef];
+};

--- a/src/module.ts
+++ b/src/module.ts
@@ -37,11 +37,20 @@ import {
   SAVE_DEFAULT_BUTTON_DEFAULT,
   SUBMIT_BUTTON_DEFAULT,
   UPDATE_CODE_DEFAULT,
+  UPDATE_ENABLED_OPTIONS,
   UPDATE_PAYLOAD_DEFAULT,
   UPDATE_REQUEST_METHOD_OPTIONS,
 } from './constants';
 import { getMigratedOptions } from './migration';
-import { ButtonOrientation, ButtonSize, ButtonVariant, CodeEditorType, PanelOptions, RequestOptions } from './types';
+import {
+  ButtonOrientation,
+  ButtonSize,
+  ButtonVariant,
+  CodeEditorType,
+  PanelOptions,
+  RequestOptions,
+  UpdateEnabledMode,
+} from './types';
 
 /**
  * Panel Plugin
@@ -286,6 +295,15 @@ export const plugin = new PanelPlugin<PanelOptions>(FormPanel)
      * Update Request
      */
     builder
+      .addRadio({
+        path: 'updateEnabled',
+        name: 'Enable Update',
+        category: ['Update Request'],
+        settings: {
+          options: UPDATE_ENABLED_OPTIONS,
+        },
+        defaultValue: UpdateEnabledMode.AUTO,
+      })
       .addRadio({
         path: 'update.method',
         name: 'Update Action',

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -5,6 +5,15 @@ import { ModalOptions } from './modal';
 import { RequestOptions, ResetAction } from './request';
 
 /**
+ * Update Enabled Mode
+ */
+export enum UpdateEnabledMode {
+  DISABLED = 'disabled',
+  AUTO = 'auto',
+  MANUAL = 'manual',
+}
+
+/**
  * Panel Options
  */
 export interface PanelOptions {
@@ -20,6 +29,13 @@ export interface PanelOptions {
    * @type {RequestOptions}
    */
   initial: RequestOptions;
+
+  /**
+   * Update Enabled
+   *
+   * @type {UpdateEnabledMode}
+   */
+  updateEnabled: UpdateEnabledMode;
 
   /**
    * Update Values


### PR DESCRIPTION
Resolves #337

1. Update enabled mode option:
<img width="499" alt="Screenshot 2024-02-27 at 10 40 36" src="https://github.com/VolkovLabs/volkovlabs-form-panel/assets/15867703/9700c649-302e-42ac-b63a-2bcb46767edb">

Disabled - hide submit button
Auto (current value) - submit button is shown, button enabled only if value changed from initial
Manual - submit button is shown and disabled by default. Control through the code. Also added supporting enableSubmit and disableSubmit functions in request code.

2. Fix sync mode.  If form element doesn't have initial value, it won't be cleaned anymore
3. Add examples with using variables
