### PR TITLE
Allow to disable columns in confirmation modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add files upload examples and fix form data header (#357)
 - Add code parameters with builder and add initial request to element value changed code (#358)
+- Allow to disable columns in confirmation modal (#360)
 
 ## 3.6.0 (2023-01-10)
 

--- a/src/components/FormPanel/FormPanel.tsx
+++ b/src/components/FormPanel/FormPanel.tsx
@@ -43,7 +43,14 @@ import {
   TEST_IDS,
 } from '../../constants';
 import { useDatasourceRequest, useFormElements, useMutableState } from '../../hooks';
-import { ButtonVariant, FormElement, LocalFormElement, PanelOptions, UpdateEnabledMode } from '../../types';
+import {
+  ButtonVariant,
+  FormElement,
+  LocalFormElement,
+  ModalColumnName,
+  PanelOptions,
+  UpdateEnabledMode,
+} from '../../types';
 import {
   convertToElementValue,
   fileToBase64,
@@ -1066,19 +1073,25 @@ export const FormPanel: React.FC<Props> = ({
         body={
           <div data-testid={TEST_IDS.panel.confirmModalContent}>
             <h4>{options.confirmModal.body}</h4>
-            {options.layout.variant !== LayoutVariant.NONE && (
+            {options.layout.variant !== LayoutVariant.NONE && options.confirmModal.columns.include.length > 0 && (
               <table className={styles.confirmTable}>
                 <thead>
                   <tr className={styles.confirmTable}>
-                    <td className={styles.confirmTableTd}>
-                      <b>{options.confirmModal.columns.name}</b>
-                    </td>
-                    <td className={styles.confirmTableTd}>
-                      <b>{options.confirmModal.columns.oldValue}</b>
-                    </td>
-                    <td className={styles.confirmTableTd}>
-                      <b>{options.confirmModal.columns.newValue}</b>
-                    </td>
+                    {options.confirmModal.columns.include.includes(ModalColumnName.NAME) && (
+                      <td className={styles.confirmTableTd}>
+                        <b>{options.confirmModal.columns.name}</b>
+                      </td>
+                    )}
+                    {options.confirmModal.columns.include.includes(ModalColumnName.OLD_VALUE) && (
+                      <td className={styles.confirmTableTd}>
+                        <b>{options.confirmModal.columns.oldValue}</b>
+                      </td>
+                    )}
+                    {options.confirmModal.columns.include.includes(ModalColumnName.NEW_VALUE) && (
+                      <td className={styles.confirmTableTd}>
+                        <b>{options.confirmModal.columns.newValue}</b>
+                      </td>
+                    )}
                   </tr>
                 </thead>
                 <tbody>
@@ -1104,18 +1117,24 @@ export const FormPanel: React.FC<Props> = ({
                           key={element.id}
                           data-testid={TEST_IDS.panel.confirmModalField(element.id)}
                         >
-                          <td className={styles.confirmTableTd} data-testid={TEST_IDS.panel.confirmModalFieldTitle}>
-                            {element.title || element.tooltip}
-                          </td>
-                          <td
-                            className={styles.confirmTableTd}
-                            data-testid={TEST_IDS.panel.confirmModalFieldPreviousValue}
-                          >
-                            *********
-                          </td>
-                          <td className={styles.confirmTableTd} data-testid={TEST_IDS.panel.confirmModalFieldValue}>
-                            *********
-                          </td>
+                          {options.confirmModal.columns.include.includes(ModalColumnName.NAME) && (
+                            <td className={styles.confirmTableTd} data-testid={TEST_IDS.panel.confirmModalFieldTitle}>
+                              {element.title || element.tooltip}
+                            </td>
+                          )}
+                          {options.confirmModal.columns.include.includes(ModalColumnName.OLD_VALUE) && (
+                            <td
+                              className={styles.confirmTableTd}
+                              data-testid={TEST_IDS.panel.confirmModalFieldPreviousValue}
+                            >
+                              *********
+                            </td>
+                          )}
+                          {options.confirmModal.columns.include.includes(ModalColumnName.NEW_VALUE) && (
+                            <td className={styles.confirmTableTd} data-testid={TEST_IDS.panel.confirmModalFieldValue}>
+                              *********
+                            </td>
+                          )}
                         </tr>
                       );
                     }
@@ -1134,18 +1153,24 @@ export const FormPanel: React.FC<Props> = ({
                         key={element.id}
                         data-testid={TEST_IDS.panel.confirmModalField(element.id)}
                       >
-                        <td className={styles.confirmTableTd} data-testid={TEST_IDS.panel.confirmModalFieldTitle}>
-                          {element.title || element.tooltip}
-                        </td>
-                        <td
-                          className={styles.confirmTableTd}
-                          data-testid={TEST_IDS.panel.confirmModalFieldPreviousValue}
-                        >
-                          {initial[element.id] === undefined ? '' : String(initial[element.id])}
-                        </td>
-                        <td className={styles.confirmTableTd} data-testid={TEST_IDS.panel.confirmModalFieldValue}>
-                          {currentValue === undefined ? '' : String(currentValue)}
-                        </td>
+                        {options.confirmModal.columns.include.includes(ModalColumnName.NAME) && (
+                          <td className={styles.confirmTableTd} data-testid={TEST_IDS.panel.confirmModalFieldTitle}>
+                            {element.title || element.tooltip}
+                          </td>
+                        )}
+                        {options.confirmModal.columns.include.includes(ModalColumnName.OLD_VALUE) && (
+                          <td
+                            className={styles.confirmTableTd}
+                            data-testid={TEST_IDS.panel.confirmModalFieldPreviousValue}
+                          >
+                            {initial[element.id] === undefined ? '' : String(initial[element.id])}
+                          </td>
+                        )}
+                        {options.confirmModal.columns.include.includes(ModalColumnName.NEW_VALUE) && (
+                          <td className={styles.confirmTableTd} data-testid={TEST_IDS.panel.confirmModalFieldValue}>
+                            {currentValue === undefined ? '' : String(currentValue)}
+                          </td>
+                        )}
                       </tr>
                     );
                   })}

--- a/src/constants/confirm-modal.ts
+++ b/src/constants/confirm-modal.ts
@@ -1,0 +1,19 @@
+import { ModalColumnName } from '../types';
+
+/**
+ * Confirm Modal Columns Include Options
+ */
+export const CONFIRM_MODAL_COLUMNS_INCLUDE_OPTIONS = [
+  {
+    value: ModalColumnName.NAME,
+    label: 'Name',
+  },
+  {
+    value: ModalColumnName.OLD_VALUE,
+    label: 'Old Value',
+  },
+  {
+    value: ModalColumnName.NEW_VALUE,
+    label: 'New Value',
+  },
+];

--- a/src/constants/default.ts
+++ b/src/constants/default.ts
@@ -4,6 +4,7 @@ import {
   CodeLanguage,
   CodeOptions,
   FormElement,
+  ModalColumnName,
   ModalOptions,
   NumberOptions,
   SelectOptions,
@@ -187,6 +188,7 @@ export const CONFIRM_MODAL_DEFAULT: ModalOptions = {
   title: 'Confirm update request',
   body: 'Please confirm to update changed values',
   columns: {
+    include: [ModalColumnName.NAME, ModalColumnName.OLD_VALUE, ModalColumnName.NEW_VALUE],
     name: 'Label',
     oldValue: 'Old Value',
     newValue: 'New Value',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,6 @@
 export * from './button';
 export * from './code-editor';
+export * from './confirm-modal';
 export * from './data';
 export * from './default';
 export * from './form-element';

--- a/src/module.test.ts
+++ b/src/module.test.ts
@@ -18,6 +18,7 @@ describe('plugin', () => {
     addSelect: jest.fn().mockImplementation(() => builder),
     addSliderInput: jest.fn().mockImplementation(() => builder),
     addTextInput: jest.fn().mockImplementation(() => builder),
+    addMultiSelect: jest.fn().mockImplementation(() => builder),
   };
 
   it('Should be instance of PanelPlugin', () => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -15,6 +15,7 @@ import {
   BUTTON_SIZE_OPTIONS,
   BUTTON_VARIANT_HIDDEN_OPTIONS,
   BUTTON_VARIANT_OPTIONS,
+  CONFIRM_MODAL_COLUMNS_INCLUDE_OPTIONS,
   CONFIRM_MODAL_DEFAULT,
   CONTENT_TYPE_OPTIONS,
   ContentType,
@@ -47,6 +48,7 @@ import {
   ButtonSize,
   ButtonVariant,
   CodeEditorType,
+  ModalColumnName,
   PanelOptions,
   RequestOptions,
   UpdateEnabledMode,
@@ -435,26 +437,37 @@ export const plugin = new PanelPlugin<PanelOptions>(FormPanel)
         defaultValue: CONFIRM_MODAL_DEFAULT.body,
         showIf: (config) => config.update.confirm,
       })
+      .addMultiSelect({
+        path: 'confirmModal.columns.include',
+        name: 'Include columns',
+        category: ['Update Confirmation Window'],
+        defaultValue: CONFIRM_MODAL_DEFAULT.columns.include as unknown,
+        showIf: (config) => config.update.confirm,
+        settings: {
+          options: CONFIRM_MODAL_COLUMNS_INCLUDE_OPTIONS,
+        },
+      })
       .addTextInput({
         path: 'confirmModal.columns.name',
         name: 'Label column',
         category: ['Update Confirmation Window'],
         defaultValue: CONFIRM_MODAL_DEFAULT.columns.name,
-        showIf: (config) => config.update.confirm,
+        showIf: (config) => config.update.confirm && config.confirmModal.columns.include.includes(ModalColumnName.NAME),
       })
       .addTextInput({
         path: 'confirmModal.columns.oldValue',
         name: 'Old value column',
         category: ['Update Confirmation Window'],
         defaultValue: CONFIRM_MODAL_DEFAULT.columns.oldValue,
-        showIf: (config) => config.update.confirm,
+        showIf: (config) =>
+          config.update.confirm && config.confirmModal.columns.include.includes(ModalColumnName.OLD_VALUE),
       })
       .addTextInput({
         path: 'confirmModal.columns.newValue',
         name: 'New value column',
         category: ['Update Confirmation Window'],
         defaultValue: CONFIRM_MODAL_DEFAULT.columns.newValue,
-        showIf: (config) => config.update.confirm,
+        showIf: (config) => config.update.confirm && config.confirmModal.columns.include.includes(ModalColumnName.NAME),
       })
       .addTextInput({
         path: 'confirmModal.confirm',

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -1,4 +1,13 @@
 /**
+ * Modal Column Name
+ */
+export enum ModalColumnName {
+  NAME = 'name',
+  OLD_VALUE = 'oldValue',
+  NEW_VALUE = 'newValue',
+}
+
+/**
  * Modal Options
  */
 export interface ModalOptions {
@@ -20,6 +29,13 @@ export interface ModalOptions {
    * Columns
    */
   columns: {
+    /**
+     * Include
+     *
+     * @type {ModalColumnName[]}
+     */
+    include: ModalColumnName[];
+
     /**
      * Name
      *


### PR DESCRIPTION
Resolves #342 

Include columns option
<img width="500" alt="Screenshot 2024-03-01 at 09 14 09" src="https://github.com/VolkovLabs/volkovlabs-form-panel/assets/15867703/2db37518-914e-4e73-b810-71298a95c205">
