### PR TITLE
Fix e2e pipeline and remove docker container names to prevent conflicts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 services:
   server:
-    container_name: server
     build:
       context: ./server-json
     ports:
@@ -10,7 +9,6 @@ services:
       - main
 
   grafana:
-    container_name: grafana
     image: ghcr.io/volkovlabs/app:latest
     ports:
       - 3000:3000/tcp
@@ -25,7 +23,6 @@ services:
       - dev
 
   postgres:
-    container_name: postgres
     image: postgres
     restart: always
     environment:
@@ -39,7 +36,6 @@ services:
       - main
 
   server-pg:
-    container_name: server-pg
     build:
       context: ./server-pg
     ports:
@@ -56,7 +52,6 @@ services:
       - main
 
   grafana-main:
-    container_name: grafana-main
     image: grafana/grafana:main
     ports:
       - 3000:3000/tcp
@@ -71,7 +66,6 @@ services:
       - main
 
   test:
-    container_name: test-e2e
     build:
       context: .
       dockerfile: test/Dockerfile

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "stop": "docker compose down",
     "test": "jest --watch --onlyChanged",
     "test:e2e": "npx playwright test",
-    "test:e2e:docker": "docker compose --profile e2e up",
+    "test:e2e:docker": "docker compose --profile e2e up --exit-code-from test",
     "test:ci": "jest --maxWorkers 4 --coverage",
     "upgrade": "npm upgrade --save"
   },


### PR DESCRIPTION
Auto-generated container names:
<img width="264" alt="Screenshot 2024-07-11 at 10 43 09" src="https://github.com/VolkovLabs/volkovlabs-form-panel/assets/15867703/6ba17048-db80-4e34-a67c-feadc5d70d7c">

If container_name is not specified for the service, it will be generated automatically from service name + suffix if the same container name already exists. It is good and allows to prevent conflicts for the local development
